### PR TITLE
OI Sensitivity Modes for joysticksAdded navx_frc.json

### DIFF
--- a/DeepSpace/src/main/java/frc/robot/OI.java
+++ b/DeepSpace/src/main/java/frc/robot/OI.java
@@ -7,6 +7,9 @@
 
 package frc.robot;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.buttons.JoystickButton;
+
+import frc.robot.commands.SetSensitivity;
 
 /**
  * This class contains all of the objects for the operator interface
@@ -15,4 +18,15 @@ public class OI {
 
     public static Joystick m_leftStick = new Joystick(0);
     public static Joystick m_rightStick = new Joystick(1);
+
+    public static JoystickButton sensUp = new JoystickButton(m_rightStick, 5);
+    public static JoystickButton sensDown = new JoystickButton(m_rightStick, 3);
+    public static int sensitivity = 5; //from 1-10
+
+
+    public OI()
+    {
+        sensUp.whenPressed(new SetSensitivity(true));
+        sensDown.whenPressed(new SetSensitivity(false));
+    }
 }

--- a/DeepSpace/src/main/java/frc/robot/Robot.java
+++ b/DeepSpace/src/main/java/frc/robot/Robot.java
@@ -42,9 +42,11 @@ public class Robot extends TimedRobot {
 
     main = CameraServer.getInstance().startAutomaticCapture(); //start camera server
     main.setResolution(310, 240); //set resolution of camera
+  }
 
-    Command setColor = new SetLEDColor(255, 0, 0); //set color of LED to red
-    Scheduler.getInstance().run();
+  @Override
+  public void teleopInit() {
+    SmartDashboard.putNumber("Joystick Sensitivity", OI.sensitivity); //display current joystick sensitivity to the dashboard
   }
 
   @Override

--- a/DeepSpace/src/main/java/frc/robot/commands/SetSensitivity.java
+++ b/DeepSpace/src/main/java/frc/robot/commands/SetSensitivity.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import frc.robot.OI;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;;
+
+public class SetSensitivity extends InstantCommand {
+  
+  private boolean upOrDown;
+  
+  /** 
+   * true for up, false for down
+   * */
+  public SetSensitivity(boolean _upOrDown) 
+  {
+    upOrDown = _upOrDown;
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() 
+  {
+    int sensitivity = OI.sensitivity; //get the sensitivity from OI
+    if(sensitivity > 10 || sensitivity < 0)
+    {
+        sensitivity = 5;
+    }
+    if(upOrDown == true && sensitivity != 10)
+    {
+        sensitivity++;
+    }
+    else if(upOrDown == false && sensitivity != 0)
+    {
+        sensitivity--;
+    }
+    OI.sensitivity = sensitivity; //set OI sensitivity to the new value
+    System.out.println("Changed sensitivity of joysitcks: " + sensitivity); //print the sensitivity change
+    SmartDashboard.putNumber("Joystick Sensitivity", sensitivity); //update the sensitivity on the shuffleboard
+  }
+}

--- a/DeepSpace/src/main/java/frc/robot/commands/TeleOpDrive.java
+++ b/DeepSpace/src/main/java/frc/robot/commands/TeleOpDrive.java
@@ -16,6 +16,9 @@ import frc.robot.OI;
  * This command controls the movement of the tank drive through the operator's joysticks
  */
 public class TeleOpDrive extends Command {
+
+  double sensitivity;
+
   public TeleOpDrive() {
   }
 
@@ -24,9 +27,13 @@ public class TeleOpDrive extends Command {
   }
 
   @Override
-  protected void execute() {
-      //take the y axis values from each joystick and send them to the swervedrive
-      RobotMap.driveBase.tankDrive(-OI.m_leftStick.getY(), -OI.m_rightStick.getY());
+  protected void execute() 
+  {
+    //the joystick values will be modified by the sensitivity of the Joysticks
+    sensitivity = OI.sensitivity / 5; //get sensitivity from OI and divide it by 5 to scale it down, so mode 10 will be 2x speed and mode 5 will be normal speed
+
+    //take the y axis values from each joystick and send them to the swervedrive
+    RobotMap.driveBase.tankDrive(-OI.m_leftStick.getY() * sensitivity, -OI.m_rightStick.getY() * sensitivity);
   }
 
 //#region Unused Methods

--- a/DeepSpace/vendordeps/navx_frc.json
+++ b/DeepSpace/vendordeps/navx_frc.json
@@ -1,0 +1,33 @@
+{
+    "fileName": "navx_frc.json",
+    "name": "KauaiLabs_navX_FRC",
+    "version": "3.1.344",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "mavenUrls": [
+        "https://repo1.maven.org/maven2/"
+    ],
+    "jsonUrl": "https://www.kauailabs.com/dist/frc/2019/navx_frc.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-java",
+            "version": "3.1.344"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-cpp",
+            "version": "3.1.344",
+            "headerClassifier": "headers",
+            "sourcesClassifier": "sources",
+            "sharedLibrary": false,
+            "libName": "navx_frc",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Using buttons 4 and 6 on the right joystick, the driver can now change the sensitivity of the robot on a range from 0-10, defaulting at 5.  I also added navx_frc.json which is the library for the NavX navigation sensor that I will be working on implementing next.  See the section under the wiki page Sensors for more information on the NavX sensor.